### PR TITLE
Updated the store identity endpoint to include non-unique blockchain …

### DIFF
--- a/dapp-verifier/verifier-api/.gitignore
+++ b/dapp-verifier/verifier-api/.gitignore
@@ -21,6 +21,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+yarn.lock
 
 # artifacts
 /artifacts

--- a/dapp-verifier/verifier-api/src/controllers/IdentityController.ts
+++ b/dapp-verifier/verifier-api/src/controllers/IdentityController.ts
@@ -53,7 +53,7 @@ identityRouter.get("/blockchainaddress/:bcAddress", async (req: Request, res: Re
 		console.log("Received request");
 		console.log(req.body);
         const identityItem = req.body;
-		const commitment = identityItem.identityCommitment.toString();
+		const commitment = identityItem.commitment.toString();
 		const bcAddress = identityItem.blockchainAddress.toString();
 		const zkProof = identityItem.zkProof.toString();
 

--- a/dapp-verifier/verifier-api/src/schemas/UserIdentitySchema.ts
+++ b/dapp-verifier/verifier-api/src/schemas/UserIdentitySchema.ts
@@ -7,12 +7,10 @@ export const UserIdentitySchema = new mongoose.Schema({
 	},
 	blockchainAddress: {
 		type: String,
-		required: true,
-        unique: true
+		required: true
 	},
     zkProof: {
 		type: String,
-		required: true,
-        unique: true
+		required: true
 	}
 });

--- a/dapp-verifier/verifier-api/src/swagger.json
+++ b/dapp-verifier/verifier-api/src/swagger.json
@@ -192,7 +192,7 @@
         },
         "UserIdentitySchema": {
             "properties": {
-                "identityCommitment": {
+                "commitment": {
                     "type": "string",
                     "example": "1234567...",
                     "required": true
@@ -211,7 +211,7 @@
         },
         "UserIdentityResponseSchema": {
             "properties": {
-                "identityCommitment": {
+                "commitment": {
                     "type": "string",
                     "example": "1234567...",
                     "required": true


### PR DESCRIPTION
…address and zk proof

1. Fixed the bug in the POST /identity method. Needed to use .commitment instead of .identityCommitment from req.body
2. After the ZK Proof and the signature from blockchain address is verified, we store the triplet of <identityCommitment, blockchainAddress, ZK Proof>. Earlier, all three were kept to be unique but one blockchain address can have multiple identityCommitments associated with it, therefore, removed the uniqueness property from blockchainAddress and ZKProof. 